### PR TITLE
GitHub Pages デプロイ設定を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/tree-outliner-sync/',
 })


### PR DESCRIPTION
## Summary
- `vite.config.ts` に `base: '/tree-outliner-sync/'` を追加し、GitHub Pages のサブパスで正しく動作するよう設定
- `.github/workflows/deploy.yml` を追加し、main ブランチへのプッシュ時に自動で GitHub Pages へデプロイ

## マージ後の手順
- リポジトリの Settings → Pages → Source で **GitHub Actions** を選択してください
- デプロイ後、`https://taktamur.github.io/tree-outliner-sync/` でアクセス可能になります

## Test plan
- [x] `npm run build` が正常に完了することを確認
- [ ] マージ後、GitHub Actions のワークフローが正常に実行されることを確認
- [ ] GitHub Pages でサイトが正しく表示されることを確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)