### PR TITLE
feat: 画面下部にキーボードショートカット常時表示バーを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,17 @@
 .app {
   display: flex;
+  flex-direction: column;
   height: 100vh;
   width: 100vw;
   overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.app-main {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .panel-left {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,21 @@
 import OutlinerPanel from './components/OutlinerPanel/OutlinerPanel';
 import TreePanel from './components/TreePanel/TreePanel';
+import ShortcutBar from './components/ShortcutBar/ShortcutBar';
 import './App.css';
 
 function App() {
   return (
     <div className="app">
-      <div className="panel-left">
-        <OutlinerPanel />
+      <div className="app-main">
+        <div className="panel-left">
+          <OutlinerPanel />
+        </div>
+        <div className="panel-divider" />
+        <div className="panel-right">
+          <TreePanel />
+        </div>
       </div>
-      <div className="panel-divider" />
-      <div className="panel-right">
-        <TreePanel />
-      </div>
+      <ShortcutBar />
     </div>
   );
 }

--- a/src/components/ShortcutBar/ShortcutBar.css
+++ b/src/components/ShortcutBar/ShortcutBar.css
@@ -1,0 +1,50 @@
+.shortcut-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 16px;
+  background-color: #f5f5f5;
+  border-top: 1px solid #e0e0e0;
+  font-size: 13px;
+  color: #555;
+  flex-shrink: 0;
+}
+
+.shortcut-section {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.shortcut-title {
+  font-weight: 600;
+  color: #333;
+  margin-right: 4px;
+}
+
+.shortcut-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.shortcut-divider {
+  width: 1px;
+  height: 20px;
+  background-color: #d0d0d0;
+}
+
+kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #333;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
+  font-family: 'Courier New', Courier, monospace;
+  white-space: nowrap;
+}

--- a/src/components/ShortcutBar/ShortcutBar.tsx
+++ b/src/components/ShortcutBar/ShortcutBar.tsx
@@ -1,0 +1,35 @@
+import './ShortcutBar.css';
+
+const ShortcutBar = () => {
+  return (
+    <div className="shortcut-bar">
+      <div className="shortcut-section">
+        <span className="shortcut-title">Outliner:</span>
+        <span className="shortcut-item">
+          <kbd>Tab</kbd> インデント
+        </span>
+        <span className="shortcut-item">
+          <kbd>Shift</kbd>+<kbd>Tab</kbd> アウトデント
+        </span>
+        <span className="shortcut-item">
+          <kbd>Enter</kbd> 追加
+        </span>
+        <span className="shortcut-item">
+          <kbd>Backspace</kbd> 削除（空時）
+        </span>
+        <span className="shortcut-item">
+          <kbd>↑</kbd>/<kbd>↓</kbd> 移動
+        </span>
+      </div>
+      <div className="shortcut-divider" />
+      <div className="shortcut-section">
+        <span className="shortcut-title">Tree:</span>
+        <span className="shortcut-item">クリック: 選択</span>
+        <span className="shortcut-item">ドラッグ: 移動</span>
+        <span className="shortcut-item">空白にドロップ: ルート化</span>
+      </div>
+    </div>
+  );
+};
+
+export default ShortcutBar;


### PR DESCRIPTION
画面下部にキーボードショートカットを常時表示するバーを追加しました。

## 変更内容
- ShortcutBarコンポーネントを新規作成
- Outliner側のショートカット（Tab, Shift+Tab, Enter, Backspace, ↑/↓）を表示
- Tree側の操作（クリック、ドラッグ、ドロップ）を表示
- App.tsxのレイアウトを縦方向に変更し、ShortcutBarを最下部に配置

Fixes #5

Generated with [Claude Code](https://claude.ai/code)