### PR TITLE
claude-code-review で claude[bot] のPR更新時もレビューを実行可能にする

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'claude[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` の `allowed_bots` に `claude[bot]` を追加
- bot が push した PR でもコードレビューワークフローが実行されるようにする
- セキュリティ上、全 bot を許可（`*`）ではなく `claude[bot]` のみに限定

## Background
[#16](https://github.com/taktamur/tree-outliner-sync/issues/16) で報告された通り、claude[bot] が PR を更新した際にレビューワークフローが `non-human actor` エラーでブロックされていた。

## Test plan
- [ ] claude[bot] が PR を push した際にレビューワークフローが正常に実行されることを確認

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)