### PR TITLE
Cloudflare Pages対応: PRプレビュー環境の追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
       - run: npm ci
       - run: npm run build
+        env:
+          VITE_BASE_PATH: /tree-outliner-sync/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/tree-outliner-sync/',
-})
+  base: process.env.VITE_BASE_PATH || "/",
+});


### PR DESCRIPTION
## 概要

Cloudflare Pagesを使ったPR単位のプレビュー環境を実現するための変更です。

## 変更内容

- **vite.config.ts**: `VITE_BASE_PATH` 環境変数でbaseパスを動的に切替
  - Cloudflare Pages: デフォルトの `/` を使用
  - GitHub Pages: `VITE_BASE_PATH=/tree-outliner-sync/` を指定
- **deploy.yml**: GitHub Pagesデプロイ時に `VITE_BASE_PATH` 環境変数を設定

## 動作

| デプロイ先 | base パス | 備考 |
|---|---|---|
| Cloudflare Pages (本番) | `/` | mainブランチ |
| Cloudflare Pages (プレビュー) | `/` | PRブランチごとに自動生成 |
| GitHub Pages | `/tree-outliner-sync/` | 環境変数で指定 |

Closes #13