### PR TITLE
feat: ドラッグ中の接続先プレビュー機能を実装

### DIFF
--- a/src/components/TreePanel/TreePanel.tsx
+++ b/src/components/TreePanel/TreePanel.tsx
@@ -94,9 +94,9 @@ const TreePanel = () => {
       return layout.edges;
     }
 
-    // ドラッグ中のノードから出ているエッジを除外
+    // ドラッグ中のノードへのエッジを除外（旧親との接続を隠す）
     const filteredEdges = layout.edges.filter(
-      (edge) => edge.source !== dragState.nodeId,
+      (edge) => edge.target !== dragState.nodeId,
     );
 
     // プレビューエッジを追加（hoverTargetIdがある場合のみ）


### PR DESCRIPTION
## 概要

ツリービジュアライゼーションでノードをドラッグ中に、接続先をリアルタイムで表示する機能を追加しました。

## 変更内容

- `onNodeDrag` ハンドラーを追加してドラッグ中のホバーターゲットを追跡
- プレビューエッジ（緑色の破線アニメーション）を表示
- ドラッグ中は元のエッジを非表示
- `findClosestNode` ヘルパー関数を抽出してコード重複を回避
- ローカル`dragState`を使用してプレビュー中はグローバルストアに影響しないように

## 視覚的フィードバック

- プレビューエッジ: 緑色 (#22c55e)、破線、アニメーション付き
- 元のエッジ: ドラッグ中は非表示
- ドロップ判定と同じ120px閾値を使用

## テスト計画

- [ ] `npm run dev` で開発サーバーを起動
- [ ] ツリービジュアライゼーションパネルでノードをドラッグ
- [ ] 緑色の破線プレビュー線がどこに接続されるかを示すことを確認
- [ ] ドラッグ中にリアルタイムでプレビューが更新されることを確認
- [ ] ノードをドロップして、プレビュー通りに接続されることを確認
- [ ] `npm run lint` および `npm run build` でエラーがないことを確認

Fixes #24

Generated with [Claude Code](https://claude.ai/code)