### PR TITLE
feat: パネルの区切りをD&Dでリサイズ可能に実装

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,11 +15,12 @@
 }
 
 .panel-left {
-  width: 350px;
+  /* width は App.tsx で動的に設定 */
   min-width: 250px;
   border-right: 1px solid #e0e0e0;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
 }
 
 .panel-divider {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,23 +9,79 @@
  * - 右パネル: TreePanel（ビジュアルツリー表示とD&D操作）
  * - 下部: ShortcutBar（キーボードショートカット一覧）
  */
+import { useState, useEffect } from 'react';
 import OutlinerPanel from './components/OutlinerPanel/OutlinerPanel';
 import TreePanel from './components/TreePanel/TreePanel';
 import ShortcutBar from './components/ShortcutBar/ShortcutBar';
 import './App.css';
 
+const DEFAULT_LEFT_PANEL_WIDTH = 350;
+const MIN_LEFT_PANEL_WIDTH = 250;
+const STORAGE_KEY = 'leftPanelWidth';
+
 /**
  * メインアプリケーション
+ *
+ * パネルリサイズ実装について:
+ * 類似ライブラリ react-resizable-panels があるが、
+ * この機能は軽量な実装で十分なため独自実装とした。
  */
 function App() {
+  // localStorageから初期値を取得、なければデフォルト値を使用
+  const [leftPanelWidth, setLeftPanelWidth] = useState(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? Number(saved) : DEFAULT_LEFT_PANEL_WIDTH;
+  });
+
+  // 幅の変更をlocalStorageに保存
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(leftPanelWidth));
+  }, [leftPanelWidth]);
+
+  /**
+   * マウスダウン時のハンドラ
+   * ドキュメント全体にmousemove/mouseupリスナーを追加してドラッグを処理
+   */
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = leftPanelWidth;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const delta = e.clientX - startX;
+      const newWidth = Math.max(MIN_LEFT_PANEL_WIDTH, startWidth + delta);
+      setLeftPanelWidth(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
+  /**
+   * ダブルクリック時のハンドラ
+   * デフォルト幅にリセット
+   */
+  const handleDoubleClick = () => {
+    setLeftPanelWidth(DEFAULT_LEFT_PANEL_WIDTH);
+  };
+
   return (
     <div className="app">
       <div className="app-main">
         {/* 左パネル: アウトライナー */}
-        <div className="panel-left">
+        <div className="panel-left" style={{ width: `${leftPanelWidth}px` }}>
           <OutlinerPanel />
         </div>
-        <div className="panel-divider" />
+        <div
+          className="panel-divider"
+          onMouseDown={handleMouseDown}
+          onDoubleClick={handleDoubleClick}
+        />
         {/* 右パネル: ツリー可視化 */}
         <div className="panel-right">
           <TreePanel />


### PR DESCRIPTION
### 概要

中央の区切りをD&Dで移動できるようにしました。

### 変更内容

- ✅ マウスドラッグで左パネルの幅を調整可能
- ✅ 最小幅を250pxに制限
- ✅ localStorageで幅を永続化
- ✅ ダブルクリックでデフォルト幅（350px）にリセット

### 実装アプローチ

react-resizable-panels ライブラリも検討しましたが、軽量な実装で十分なため独自実装としました。

Closes #22

Generated with [Claude Code](https://claude.ai/code)