### PR TITLE
feat: Scrapboxコピペ機能を実装

### DIFF
--- a/src/components/OutlinerPanel/OutlinerPanel.css
+++ b/src/components/OutlinerPanel/OutlinerPanel.css
@@ -15,8 +15,126 @@
   flex-shrink: 0;
 }
 
+.outliner-header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.outliner-header-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.outliner-btn {
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #555;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.outliner-btn:hover {
+  background: #f5f5f5;
+  border-color: #bbb;
+}
+
+.outliner-btn:active {
+  background: #e8e8e8;
+}
+
 .outliner-content {
   flex: 1;
   overflow-y: auto;
   padding: 8px 0;
+}
+
+/* モーダル */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 8px;
+  padding: 24px;
+  min-width: 500px;
+  max-width: 600px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.modal-content h3 {
+  margin: 0 0 16px 0;
+  font-size: 18px;
+  color: #333;
+}
+
+.import-textarea {
+  width: 100%;
+  height: 300px;
+  padding: 12px;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 13px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.import-textarea:focus {
+  outline: none;
+  border-color: #4a90e2;
+  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.1);
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.modal-btn {
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.modal-btn-cancel {
+  color: #555;
+  background: #f5f5f5;
+}
+
+.modal-btn-cancel:hover {
+  background: #e8e8e8;
+}
+
+.modal-btn-primary {
+  color: #fff;
+  background: #4a90e2;
+}
+
+.modal-btn-primary:hover {
+  background: #357abd;
+}
+
+.modal-btn-primary:active {
+  background: #2868a8;
 }

--- a/src/store/treeStore.ts
+++ b/src/store/treeStore.ts
@@ -15,6 +15,10 @@ import {
   deleteNode,
   moveNode,
 } from '../utils/treeOperations';
+import {
+  parseScrapboxToTree,
+  formatTreeToScrapbox,
+} from '../utils/scrapboxConverter';
 
 /**
  * ツリーストアの型定義
@@ -46,6 +50,12 @@ interface TreeStore {
   // ストア全体操作
   /** ノードリスト全体を置き換え */
   setNodes: (nodes: TreeNode[]) => void;
+
+  // Scrapbox連携
+  /** Scrapboxテキストからインポート（既存データは置き換えられる） */
+  importFromScrapbox: (text: string) => void;
+  /** Scrapboxテキストにエクスポート */
+  exportToScrapbox: () => string;
 }
 
 /**
@@ -123,4 +133,18 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
   setSelectedNodeId: (id) => set({ selectedNodeId: id }),
 
   setNodes: (nodes) => set({ nodes }),
+
+  importFromScrapbox: (text) => {
+    if (get().nodes.length > 0) {
+      if (!confirm('現在のデータは失われます。続行しますか?')) {
+        return;
+      }
+    }
+    const nodes = parseScrapboxToTree(text);
+    set({ nodes, selectedNodeId: null });
+  },
+
+  exportToScrapbox: () => {
+    return formatTreeToScrapbox(get().nodes);
+  },
 }));

--- a/src/utils/scrapboxConverter.ts
+++ b/src/utils/scrapboxConverter.ts
@@ -1,0 +1,91 @@
+/**
+ * Scrapbox形式のテキストとTreeNode配列の双方向変換ユーティリティ
+ *
+ * Scrapboxはインデントベースのアウトライナーで、階層構造をスペースまたはタブで表現する。
+ * 1階層につき1文字のインデント（スペースまたはタブ）を使用する。
+ */
+import type { TreeNode } from '../types/tree';
+import { generateId } from './idGenerator';
+import { getFlattenedOrder, getDepth } from './treeOperations';
+
+/**
+ * 使用されているインデント単位を検出
+ * @param lines - テキスト行の配列
+ * @returns インデント単位（スペースまたはタブ）
+ */
+const detectIndentUnit = (lines: string[]): string => {
+  for (const line of lines) {
+    const match = line.match(/^(\s+)/);
+    if (match) {
+      // 最初のインデント文字を単位とする
+      return match[1][0] === '\t' ? '\t' : ' ';
+    }
+  }
+  return ' '; // デフォルトはスペース
+};
+
+/**
+ * Scrapbox形式のテキストをTreeNode配列に変換
+ * @param text - Scrapbox形式のテキスト（改行区切り）
+ * @returns TreeNode配列
+ */
+export const parseScrapboxToTree = (text: string): TreeNode[] => {
+  const lines = text.split('\n').filter((line) => line.trim());
+  if (lines.length === 0) return [];
+
+  const nodes: TreeNode[] = [];
+  const stack: { depth: number; id: string }[] = [];
+  const indentUnit = detectIndentUnit(lines);
+
+  lines.forEach((line) => {
+    // インデントレベルを計算
+    const match = line.match(/^(\s*)/);
+    const indentStr = match ? match[1] : '';
+    // インデント単位で割ることで階層の深さを取得
+    const depth =
+      indentStr.length > 0
+        ? indentStr.split(indentUnit).length - 1
+        : 0;
+    const text = line.trim();
+
+    // 新しいノードを生成
+    const id = generateId();
+
+    // スタックを使って親を特定
+    while (stack.length > 0 && stack[stack.length - 1].depth >= depth) {
+      stack.pop();
+    }
+
+    const parentId = stack.length > 0 ? stack[stack.length - 1].id : null;
+
+    // 同じ親の子ノード数を数えてorder決定
+    const siblings = nodes.filter((n) => n.parentId === parentId);
+    const order = siblings.length;
+
+    nodes.push({ id, text, parentId, order });
+    stack.push({ depth, id });
+  });
+
+  return nodes;
+};
+
+/**
+ * TreeNode配列をScrapbox形式のテキストに変換
+ * @param nodes - TreeNode配列
+ * @returns Scrapbox形式のテキスト
+ */
+export const formatTreeToScrapbox = (nodes: TreeNode[]): string => {
+  const lines: string[] = [];
+
+  // DFS順で走査（アウトライナーの表示順序を保持）
+  const orderedNodes = getFlattenedOrder(nodes);
+
+  orderedNodes.forEach((node) => {
+    // 各ノードの深さを計算
+    const depth = getDepth(nodes, node.id);
+    const indent = ' '.repeat(depth); // 1階層=1スペース
+    lines.push(`${indent}${node.text}`);
+  });
+
+  return lines.join('\n');
+};


### PR DESCRIPTION
## 概要

Scrapbox形式のテキストとの双方向コピペ機能を実装。

## 変更内容

- `scrapboxConverter.ts`: Scrapbox形式とTreeNodeの双方向変換
- `treeStore.ts`: importFromScrapbox/exportToScrapboxメソッド追加
- `OutlinerPanel`: Import/Exportボタンとモーダルを追加

Closes #25

Generated with [Claude Code](https://claude.ai/code)