### PR TITLE
fix: Remove unnecessary selectedNodeId dependency from useEffect

### DIFF
--- a/src/components/OutlinerPanel/OutlinerItem.tsx
+++ b/src/components/OutlinerPanel/OutlinerItem.tsx
@@ -37,7 +37,7 @@ const OutlinerItem = ({ nodeId }: OutlinerItemProps) => {
     if (isSelected && inputRef.current) {
       inputRef.current.focus();
     }
-  }, [isSelected, selectedNodeId]);
+  }, [isSelected]);
 
   if (!node) return null;
 


### PR DESCRIPTION
アウトラインで1行追加すると2行になるバグを修正。

OutlinerItem.tsxのuseEffectの依存配列かselectedNodeIdを削除し、isSelectedのみを依存とすることで、不要な再実行を防止。

Fixes #38

Generated with [Claude Code](https://claude.ai/code)