### PR TITLE
fix: IME入力確定のEnterキーが兄弟ノード作成と干渉する問題を修正

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -38,7 +38,7 @@ export const useKeyboardShortcuts = (nodeId: string) => {
       } else if (e.key === 'Enter') {
         // Enter: 新しいノードを現在のノードの直後に追加
         // IME変換中（日本語入力の確定など）の場合はスキップ
-        if (e.isComposing) {
+        if (e.nativeEvent.isComposing) {
           return;
         }
         e.preventDefault();


### PR DESCRIPTION
## 変更内容

日本語入力などのBIME変換中にEnterキーを押した際、変換確定と兄弟ノード作成が同時に発生する問題を修正しました。

KeyboardEventのisComposingプロパティをチェックし、IME変換中の場合はノード追加処理をスキップするようにしました。

Fixes #41

## テスト方法

1. アウトライナーで日本語入力を行う
2. ひらがなを入力し、Enterで漢字変換を確定する
3. 変換確定のみが行われ、新しいノードが作成されないことを確認
4. 通常のEnterキーで兄弟ノードが作成されることを確認

---

Generated with [Claude Code](https://claude.ai/code)