### PR TITLE
feat: localStorageへの自動保存機能を実装

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,46 @@
+/**
+ * localStorage操作のユーティリティ関数
+ *
+ * ツリーノードの永続化を担当する。
+ * 自動保存・自動読み込みをサポートする。
+ */
+import type { TreeNode } from '../store/types';
+
+const STORAGE_KEY = 'tree-outliner-sync:nodes';
+
+/**
+ * ツリーノードをlocalStorageに保存
+ * @param nodes - 保存するTreeNode配列
+ */
+export const saveTreeState = (nodes: TreeNode[]): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(nodes));
+  } catch (error) {
+    console.error('Failed to save tree state:', error);
+  }
+};
+
+/**
+ * localStorageからツリーノードを読み込み
+ * @returns 保存されていたTreeNode配列、存在しない場合はnull
+ */
+export const loadTreeState = (): TreeNode[] | null => {
+  try {
+    const json = localStorage.getItem(STORAGE_KEY);
+    return json ? JSON.parse(json) : null;
+  } catch (error) {
+    console.error('Failed to load tree state:', error);
+    return null;
+  }
+};
+
+/**
+ * localStorageに保存されたツリーノードをクリア
+ */
+export const clearTreeState = (): void => {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to clear tree state:', error);
+  }
+};


### PR DESCRIPTION
## 概要

localStorageへの自動保存機能を実装しました。

## 変更内容

- `src/utils/storage.ts`を新規作成してlocalStorage操作を分離
- `treeStore`に自動保存・自動読み込み機能を追加
- Scrapboxインポート時にlocalStorageをクリア
- selectedNodeIdは保存対象から除外

Closes #47

Generated with [Claude Code](https://claude.ai/code)