### PR TITLE
feat: 兄弟ノードの左端を縦方向に揃える

### DIFF
--- a/src/visualization/layoutCalculator.ts
+++ b/src/visualization/layoutCalculator.ts
@@ -67,7 +67,7 @@ const layoutSubtree = (
 ): { nodes: LayoutNode[]; edges: LayoutEdge[]; height: number } => {
   // dagreグラフを初期化（LR方向: 左→右）
   const g = new dagre.graphlib.Graph();
-  g.setGraph({ rankdir: 'LR', nodesep: 20, ranksep: 80 });
+  g.setGraph({ rankdir: 'LR', nodesep: 20, ranksep: 80, align: 'UL' });
   g.setDefaultEdgeLabel(() => ({}));
 
   // サブツリーのノードを再帰的に収集


### PR DESCRIPTION
### 変更内容

dagreのalignオプションに`UL`を設定し、同じ親を持つ兄弟ノードの左端が縦方向に揃うようにしました。

Fixes #52

### テスト

- [ ] `npm run build`が通ることを確認
- [ ] `npm run lint`が通ることを確認
- [ ] 視覚的に兄弟ノードの左端が揃っていることを確認

Generated with [Claude Code](https://claude.ai/code)