### PR TITLE
fix: D&D時に親ノードが変わらない場合は元の位置に戻すよう修正

### DIFF
--- a/src/visualization/TreePanel.tsx
+++ b/src/visualization/TreePanel.tsx
@@ -168,6 +168,7 @@ const TreePanel = () => {
    *
    * ドロップ位置から新しい親を判定し、ドラッグ開始時の親と異なる場合のみ移動する。
    * これにより、「レイアウト調整のためのドラッグ」と「親子関係変更のためのドラッグ」を区別できる。
+   * 親が変わらない場合は、レイアウト位置に戻すため強制的に再レイアウトする。
    */
   const onNodeDragStop: NodeMouseHandler = useCallback(
     (_event, draggedNode) => {
@@ -186,12 +187,15 @@ const TreePanel = () => {
       // 親が実際に変わった場合のみ move() を実行
       if (newParentId !== originalParentId) {
         move(draggedNode.id, newParentId);
+      } else {
+        // 親が変わらない場合は、元のレイアウト位置に戻す
+        setFlowNodes(layoutNodes);
       }
 
       // ドラッグ状態をリセット
       setDragState({ nodeId: null, hoverTargetId: null, originalParentId: undefined });
     },
-    [nodeToRect, layoutNodes, move, dragState.originalParentId],
+    [nodeToRect, layoutNodes, move, dragState.originalParentId, setFlowNodes],
   );
 
   return (


### PR DESCRIPTION
## 概要

D&D時に親ノードが変わらない場合、ノード位置を元に戻すよう修正しました。

## 変更内容

- `onNodeDragStop`で親ノードが変わらなかった場合、`setFlowNodes(layoutNodes)`を呼び出し
- レイアウト計算済みの位置に戻すように変更

Closes #73

---

Generated with [Claude Code](https://claude.ai/code)