### PR TITLE
fix: アウトライナーとツリー表示の順序を一致させる

### DIFF
--- a/src/visualization/layoutCalculator.ts
+++ b/src/visualization/layoutCalculator.ts
@@ -130,6 +130,8 @@ const layoutSubtree = async (
       'elk.layered.spacing.nodeNodeBetweenLayers': '80',
       'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
       'elk.layered.nodePlacement.bk.fixedAlignment': 'LEFTUP',
+      'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
+      'elk.layered.crossingMinimization.semiInteractive': 'true',
     },
     children: elkNodes,
     edges,


### PR DESCRIPTION
## 概要

elkjsのレイアウトオプションを追加し、アウトライナーパネルとツリー可視化パネルの表示順序が一致するようにしました。

## 変更内容

- `src/visualization/layoutCalculator.ts` にlayoutOptionsに以下を追加:
  - `elk.layered.considerModelOrder.strategy: 'NODES_AND_EDGES'`
  - `elk.layered.crossingMinimization.semiInteractive: 'true'`

## 詳細

elkjsのレイアウトアルゴリズムが、`getChildren()` 関数が返す `order` フィールドでソートされた順序を無視していたことが原因でした。追加したオプションにより、elkjsがノード配列の順序を考慮するようになります。

Fixes #76

---

Generated with [Claude Code](https://claude.ai/code)