### PR TITLE
feat: デバッグパネル追加（Ctrl+Shift+D でトグル）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,14 @@
  * - 左パネル: OutlinerPanel（テキストベースの階層編集）
  * - 右パネル: TreePanel（ビジュアルツリー表示とD&D操作）
  * - 下部: ShortcutBar（キーボードショートカット一覧）
+ * - オーバーレイ: DebugPanel（Ctrl+Shift+D で表示）
  */
 import { useState, useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 import OutlinerPanel from './outliner/OutlinerPanel';
 import TreePanel from './visualization/TreePanel';
 import ShortcutBar from './shared/components/ShortcutBar/ShortcutBar';
+import DebugPanel from './shared/components/DebugPanel/DebugPanel';
 import './App.css';
 
 const DEFAULT_LEFT_PANEL_WIDTH = 350;
@@ -34,10 +36,26 @@ function App() {
     return saved ? Number(saved) : DEFAULT_LEFT_PANEL_WIDTH;
   });
 
+  // デバッグパネルの表示/非表示
+  const [isDebugPanelVisible, setIsDebugPanelVisible] = useState(false);
+
   // 幅の変更をlocalStorageに保存
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, String(leftPanelWidth));
   }, [leftPanelWidth]);
+
+  // Ctrl+Shift+D でデバッグパネルをトグル
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'D') {
+        e.preventDefault();
+        setIsDebugPanelVisible((prev) => !prev);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   /**
    * マウスダウン時のハンドラ
@@ -112,6 +130,11 @@ function App() {
       </div>
       {/* キーボードショートカット表示 */}
       <ShortcutBar />
+      {/* デバッグパネル (Ctrl+Shift+D でトグル) */}
+      <DebugPanel
+        isVisible={isDebugPanelVisible}
+        onClose={() => setIsDebugPanelVisible(false)}
+      />
     </div>
   );
 }

--- a/src/shared/components/DebugPanel/DebugPanel.css
+++ b/src/shared/components/DebugPanel/DebugPanel.css
@@ -1,0 +1,275 @@
+/**
+ * デバッグパネルのスタイル
+ *
+ * オーバーレイ表示、ドラッグ可能、リサイズ可能なパネル
+ */
+
+.debug-panel {
+  position: fixed;
+  z-index: 9999;
+  background: #1e1e1e;
+  border: 2px solid #4a90e2;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #e0e0e0;
+  overflow: hidden;
+}
+
+/* ヘッダー */
+.debug-panel-header {
+  background: #2d2d2d;
+  padding: 10px 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: move;
+  border-bottom: 1px solid #3d3d3d;
+  user-select: none;
+}
+
+.debug-panel-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: #4a90e2;
+}
+
+.debug-panel-close {
+  background: transparent;
+  border: none;
+  color: #e0e0e0;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.debug-panel-close:hover {
+  background: #ff4444;
+}
+
+/* 統計情報 */
+.debug-panel-stats {
+  background: #252525;
+  padding: 8px 15px;
+  display: flex;
+  gap: 20px;
+  font-size: 12px;
+  border-bottom: 1px solid #3d3d3d;
+  flex-shrink: 0;
+}
+
+.debug-panel-stats span {
+  color: #b0b0b0;
+}
+
+/* タブ */
+.debug-panel-tabs {
+  display: flex;
+  background: #2d2d2d;
+  border-bottom: 1px solid #3d3d3d;
+  flex-shrink: 0;
+}
+
+.debug-panel-tabs button {
+  flex: 1;
+  padding: 10px 15px;
+  background: transparent;
+  border: none;
+  color: #b0b0b0;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+  border-bottom: 2px solid transparent;
+}
+
+.debug-panel-tabs button:hover {
+  background: #353535;
+  color: #e0e0e0;
+}
+
+.debug-panel-tabs button.active {
+  color: #4a90e2;
+  border-bottom-color: #4a90e2;
+  background: #1e1e1e;
+}
+
+/* コンテンツエリア */
+.debug-panel-content {
+  flex: 1;
+  overflow: auto;
+  padding: 10px;
+  font-size: 12px;
+}
+
+/* フラット表示（テーブル） */
+.debug-panel-flat {
+  overflow: auto;
+}
+
+.debug-panel-flat table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'Courier New', monospace;
+}
+
+.debug-panel-flat th {
+  background: #2d2d2d;
+  color: #4a90e2;
+  text-align: left;
+  padding: 8px;
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  border-bottom: 2px solid #4a90e2;
+}
+
+.debug-panel-flat td {
+  padding: 6px 8px;
+  border-bottom: 1px solid #3d3d3d;
+}
+
+.debug-panel-flat tr:hover {
+  background: #2a2a2a;
+}
+
+.debug-panel-flat tr.selected {
+  background: #3a4a5a;
+}
+
+.debug-panel-id {
+  color: #888;
+  font-size: 11px;
+}
+
+/* ツリー表示 */
+.debug-panel-tree {
+  font-family: 'Courier New', monospace;
+}
+
+.debug-panel-tree-item {
+  padding: 4px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid #2d2d2d;
+  transition: background 0.15s;
+}
+
+.debug-panel-tree-item:hover {
+  background: #2a2a2a;
+}
+
+.debug-panel-tree-item.selected {
+  background: #3a4a5a;
+  border-left: 3px solid #4a90e2;
+}
+
+.debug-panel-tree-icon {
+  flex-shrink: 0;
+}
+
+.debug-panel-tree-text {
+  color: #e0e0e0;
+  flex-shrink: 0;
+}
+
+.debug-panel-tree-meta {
+  color: #888;
+  font-size: 10px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* JSON表示 */
+.debug-panel-json {
+  position: relative;
+}
+
+.debug-panel-copy-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: #4a90e2;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  z-index: 10;
+  transition: background 0.2s;
+}
+
+.debug-panel-copy-btn:hover {
+  background: #357abd;
+}
+
+.debug-panel-json pre {
+  margin: 0;
+  padding: 10px;
+  background: #252525;
+  border-radius: 4px;
+  overflow: auto;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #e0e0e0;
+  white-space: pre;
+}
+
+/* リサイズハンドル */
+.debug-panel-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 20px;
+  height: 20px;
+  cursor: nwse-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-size: 16px;
+  user-select: none;
+}
+
+.debug-panel-resize-handle:hover {
+  color: #4a90e2;
+}
+
+/* スクロールバーのスタイリング（WebKit系） */
+.debug-panel-content::-webkit-scrollbar,
+.debug-panel-flat::-webkit-scrollbar,
+.debug-panel-json pre::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.debug-panel-content::-webkit-scrollbar-track,
+.debug-panel-flat::-webkit-scrollbar-track,
+.debug-panel-json pre::-webkit-scrollbar-track {
+  background: #2d2d2d;
+}
+
+.debug-panel-content::-webkit-scrollbar-thumb,
+.debug-panel-flat::-webkit-scrollbar-thumb,
+.debug-panel-json pre::-webkit-scrollbar-thumb {
+  background: #4a90e2;
+  border-radius: 4px;
+}
+
+.debug-panel-content::-webkit-scrollbar-thumb:hover,
+.debug-panel-flat::-webkit-scrollbar-thumb:hover,
+.debug-panel-json pre::-webkit-scrollbar-thumb:hover {
+  background: #357abd;
+}

--- a/src/shared/components/DebugPanel/DebugPanel.tsx
+++ b/src/shared/components/DebugPanel/DebugPanel.tsx
@@ -1,0 +1,278 @@
+/**
+ * デバッグパネルコンポーネント
+ *
+ * ストアの状態を可視化するオーバーレイパネル。
+ * Ctrl+Shift+D で表示/非表示を切り替え可能。
+ *
+ * 表示内容:
+ * - ノード一覧（フラット表示）
+ * - ツリー構造（階層表示）
+ * - 統計情報（ノード数、ルートノード数）
+ * - JSON形式での全データ表示
+ */
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { useTreeStore } from '../../../store/treeStore';
+import type { TreeNode } from '../../../store/types';
+import './DebugPanel.css';
+
+interface DebugPanelProps {
+  /** パネルの表示/非表示 */
+  isVisible: boolean;
+  /** 閉じるボタンのコールバック */
+  onClose: () => void;
+}
+
+/**
+ * ツリー構造を階層表示用に変換
+ */
+interface TreeNodeWithDepth {
+  node: TreeNode;
+  depth: number;
+}
+
+/**
+ * ノードの階層を計算してフラット配列に変換
+ */
+const flattenTreeWithDepth = (nodes: TreeNode[]): TreeNodeWithDepth[] => {
+  const result: TreeNodeWithDepth[] = [];
+  const nodeMap = new Map<string, TreeNode>();
+  nodes.forEach((n) => nodeMap.set(n.id, n));
+
+  // ルートノードを取得（order順）
+  const roots = nodes.filter((n) => n.parentId === null).sort((a, b) => a.order - b.order);
+
+  // 再帰的に子を追加
+  const addChildren = (parentId: string | null, depth: number) => {
+    const children = nodes
+      .filter((n) => n.parentId === parentId)
+      .sort((a, b) => a.order - b.order);
+
+    children.forEach((child) => {
+      result.push({ node: child, depth });
+      addChildren(child.id, depth + 1);
+    });
+  };
+
+  // ルートノードから開始
+  roots.forEach((root) => {
+    result.push({ node: root, depth: 0 });
+    addChildren(root.id, 1);
+  });
+
+  return result;
+};
+
+/**
+ * デバッグパネル本体
+ */
+const DebugPanel = ({ isVisible, onClose }: DebugPanelProps) => {
+  const { nodes, selectedNodeId } = useTreeStore();
+  const [activeTab, setActiveTab] = useState<'flat' | 'tree' | 'json'>('flat');
+  const [position, setPosition] = useState({ x: 100, y: 100 });
+  const [size, setSize] = useState({ width: 600, height: 400 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // 統計情報の計算
+  const stats = useMemo(() => {
+    const rootCount = nodes.filter((n) => n.parentId === null).length;
+    return {
+      totalNodes: nodes.length,
+      rootNodes: rootCount,
+      childNodes: nodes.length - rootCount,
+    };
+  }, [nodes]);
+
+  // 階層表示用のデータ
+  const treeWithDepth = useMemo(() => flattenTreeWithDepth(nodes), [nodes]);
+
+  // JSON表示用のデータ
+  const jsonData = useMemo(
+    () => JSON.stringify({ nodes, selectedNodeId }, null, 2),
+    [nodes, selectedNodeId]
+  );
+
+  // ドラッグ開始
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('.debug-panel-resize-handle')) {
+      setIsResizing(true);
+      dragStartRef.current = { x: e.clientX, y: e.clientY };
+    } else if ((e.target as HTMLElement).closest('.debug-panel-header')) {
+      setIsDragging(true);
+      dragStartRef.current = {
+        x: e.clientX - position.x,
+        y: e.clientY - position.y,
+      };
+    }
+  };
+
+  // ドラッグ・リサイズ処理
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (isDragging) {
+        setPosition({
+          x: e.clientX - dragStartRef.current.x,
+          y: e.clientY - dragStartRef.current.y,
+        });
+      } else if (isResizing) {
+        const deltaX = e.clientX - dragStartRef.current.x;
+        const deltaY = e.clientY - dragStartRef.current.y;
+        setSize((prev) => ({
+          width: Math.max(400, prev.width + deltaX),
+          height: Math.max(300, prev.height + deltaY),
+        }));
+        dragStartRef.current = { x: e.clientX, y: e.clientY };
+      }
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+      setIsResizing(false);
+    };
+
+    if (isDragging || isResizing) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+    }
+  }, [isDragging, isResizing]);
+
+  // JSON をクリップボードにコピー
+  const handleCopyJson = async () => {
+    try {
+      await navigator.clipboard.writeText(jsonData);
+      alert('JSONをクリップボードにコピーしました');
+    } catch (err) {
+      console.error('コピーに失敗しました:', err);
+    }
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      ref={panelRef}
+      className="debug-panel"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+        width: `${size.width}px`,
+        height: `${size.height}px`,
+      }}
+      onMouseDown={handleMouseDown}
+    >
+      {/* ヘッダー */}
+      <div className="debug-panel-header">
+        <div className="debug-panel-title">🐛 Debug Panel</div>
+        <button className="debug-panel-close" onClick={onClose}>
+          ×
+        </button>
+      </div>
+
+      {/* 統計情報 */}
+      <div className="debug-panel-stats">
+        <span>全ノード: {stats.totalNodes}</span>
+        <span>ルート: {stats.rootNodes}</span>
+        <span>子ノード: {stats.childNodes}</span>
+        {selectedNodeId && <span>選択中: {selectedNodeId.slice(0, 8)}...</span>}
+      </div>
+
+      {/* タブ切り替え */}
+      <div className="debug-panel-tabs">
+        <button
+          className={activeTab === 'flat' ? 'active' : ''}
+          onClick={() => setActiveTab('flat')}
+        >
+          フラット表示
+        </button>
+        <button
+          className={activeTab === 'tree' ? 'active' : ''}
+          onClick={() => setActiveTab('tree')}
+        >
+          ツリー表示
+        </button>
+        <button
+          className={activeTab === 'json' ? 'active' : ''}
+          onClick={() => setActiveTab('json')}
+        >
+          JSON
+        </button>
+      </div>
+
+      {/* コンテンツエリア */}
+      <div className="debug-panel-content">
+        {/* フラット表示 */}
+        {activeTab === 'flat' && (
+          <div className="debug-panel-flat">
+            <table>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Text</th>
+                  <th>ParentID</th>
+                  <th>Order</th>
+                </tr>
+              </thead>
+              <tbody>
+                {nodes.map((node) => (
+                  <tr
+                    key={node.id}
+                    className={node.id === selectedNodeId ? 'selected' : ''}
+                  >
+                    <td className="debug-panel-id">{node.id.slice(0, 8)}...</td>
+                    <td>{node.text}</td>
+                    <td className="debug-panel-id">
+                      {node.parentId ? `${node.parentId.slice(0, 8)}...` : 'null'}
+                    </td>
+                    <td>{node.order}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* ツリー表示 */}
+        {activeTab === 'tree' && (
+          <div className="debug-panel-tree">
+            {treeWithDepth.map(({ node, depth }) => (
+              <div
+                key={node.id}
+                className={`debug-panel-tree-item ${node.id === selectedNodeId ? 'selected' : ''}`}
+                style={{ paddingLeft: `${depth * 20 + 10}px` }}
+              >
+                <span className="debug-panel-tree-icon">
+                  {node.parentId === null ? '📁' : '📄'}
+                </span>
+                <span className="debug-panel-tree-text">{node.text}</span>
+                <span className="debug-panel-tree-meta">
+                  (id: {node.id.slice(0, 8)}..., order: {node.order})
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* JSON表示 */}
+        {activeTab === 'json' && (
+          <div className="debug-panel-json">
+            <button className="debug-panel-copy-btn" onClick={handleCopyJson}>
+              📋 コピー
+            </button>
+            <pre>{jsonData}</pre>
+          </div>
+        )}
+      </div>
+
+      {/* リサイズハンドル */}
+      <div className="debug-panel-resize-handle">⋰</div>
+    </div>
+  );
+};
+
+export default DebugPanel;


### PR DESCRIPTION
## 概要

ストアの内容を表示するデバッグパネルを追加しました。`Ctrl+Shift+D` で表示/非表示を切り替えられるトグル式オーバーレイパネルです。

## 主な機能

- フラット表示：全ノードをテーブル形式で表示
- ツリー表示：階層構造をインデント付きで表示
- JSON表示：ストアの全状態をJSON形式で表示（コピー機能付き）
- 統計情報：ノード数、ルート数、選択中ノードの表示
- ドラッグ&リサイズ可能
- 選択ノードのハイライト表示

Closes #77

Generated with [Claude Code](https://claude.ai/code)